### PR TITLE
Since using the PGI Fortran compiler, use the PGI C++ compiler as well.

### DIFF
--- a/ioapi/Makeinclude.Linux2_x86_64pg
+++ b/ioapi/Makeinclude.Linux2_x86_64pg
@@ -30,10 +30,10 @@ AR   = ar
 CC   = pgcc
 FC   = pgf90
 M4   = m4
-CPP  = cpp
+CPP  = pgc++
 LINK = $(CC)
 
-MODI = "-module "       ## Module-include-directory command
+MODI = -module        ## Module-include-directory command
 E132 = -extend
 
 MFLAGS    = -fast # -Mnoupcase


### PR DESCRIPTION
I'm using the pgi 1710 community edition compilers from pgilinux-2017-1710-x86_64.tar.gz

I needed to make these changes to get this to compile with just the pgi compilers installed.

