### PR TITLE
gfortran 9.3 don't like ths sintax when i'm trying to compile the SMO…

### DIFF
--- a/ioapi/fixed_src/PARMS3.EXT
+++ b/ioapi/fixed_src/PARMS3.EXT
@@ -101,8 +101,7 @@
         INTEGER, PARAMETER :: M3INT8  =  10    !  variable type value "INTEGER*8" = nf_int64
 
         INTEGER, PARAMETER :: NM3TYPES = 4
-        INTEGER, PARAMETER :: M3TYPES( NM3TYPES ) =
-     &        (/ M3INT, M3REAL, M3DBLE, M3INT8 /)
+        INTEGER, PARAMETER :: M3TYPES( NM3TYPES )=(/ M3INT, M3REAL, M3DBLE, M3INT8 /)
             
         !!......  File storage modes:
 


### PR DESCRIPTION
hi,

I've done this modificaton, because it gives me an error when i try to compile the SMOKE emission procesor with GNU compilers.

I'm using gfortran 9.3.0 with the following flags: "-ffixed-line-length-132  -fno-backslash"

Maybe it can be solved using other flags..

Regards