### PR TITLE
Include `stdlib.h` in `ioapi/sortic.c` for exit

### DIFF
--- a/ioapi/sortic.c
+++ b/ioapi/sortic.c
@@ -46,6 +46,7 @@ REVISION HISTORY:
 
 #include  <string.h>
 #include  <stdint.h>
+#include  <stdlib.h>
 #include "parms3.h"
 
                          /**  DEAL WITH  FELDMANISMS  OF MANY UN*X F77'S   **/


### PR DESCRIPTION
The [`exit`](https://en.cppreference.com/w/c/program/exit) function requires the `stdlib.h` header file.  This PR fixes the compilation failure
```
[16:00:35] /workspace/srcdir/ioapi-3.2/ioapi/sortic.c:322:30: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
[16:00:35]         if ( ind[ i ] > n )  exit( 2 ) ;
[16:00:35]                              ^
[16:00:35] /workspace/srcdir/ioapi-3.2/ioapi/sortic.c:322:30: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```
when using Clang